### PR TITLE
APP-27: Fix not enough balance

### DIFF
--- a/src/screens/SendCrypto/SendIn/SendCrypto.js
+++ b/src/screens/SendCrypto/SendIn/SendCrypto.js
@@ -74,6 +74,10 @@ class SendCrypto extends React.Component {
       this.setFormValidation({ maxAmount: this.getMaxAmount(), minAmount: this.getMinAmount() });
       this.getSupportedFeeTypes();
     }
+
+    if (oldSelectedPrivacy && selectedPrivacy && oldSelectedPrivacy.amount !== selectedPrivacy.amount) {
+      this.setFormValidation({ maxAmount: this.getMaxAmount(), minAmount: this.getMinAmount() });
+    }
   }
 
   getMinAmount = () => {


### PR DESCRIPTION
The error is shown your balance is not enough coin although the account is enough money when inputting amount in send screen