### PR TITLE
New Wallet UI

### DIFF
--- a/src/components/EstimateFee/EstimateFee.actions.js
+++ b/src/components/EstimateFee/EstimateFee.actions.js
@@ -22,13 +22,18 @@ import {
   ACTION_INIT_FETCHED,
   ACTION_FETCHED_MAX_FEE_PRV,
   ACTION_FETCHED_MAX_FEE_PTOKEN,
+  ACTION_USE_FEE_MAX,
 } from './EstimateFee.constant';
 import { apiGetEstimateFeeFromChain } from './EstimateFee.services';
 // eslint-disable-next-line import/no-cycle
-import { estimateFeeSelector } from './EstimateFee.selector';
+import { estimateFeeSelector, feeDataSelector } from './EstimateFee.selector';
 // eslint-disable-next-line import/no-cycle
 import { formName } from './EstimateFee.input';
-import { MAX_FEE_PER_TX, DEFAULT_FEE_PER_KB } from './EstimateFee.utils';
+import {
+  MAX_FEE_PER_TX,
+  DEFAULT_FEE_PER_KB,
+  getMaxAmount,
+} from './EstimateFee.utils';
 
 export const actionInitEstimateFee = (config = {}) => async (
   dispatch,
@@ -80,12 +85,12 @@ export const actionInitEstimateFee = (config = {}) => async (
   }
 };
 
-export const actionFetchedMaxFeePrv = payload => ({
+export const actionFetchedMaxFeePrv = (payload) => ({
   type: ACTION_FETCHED_MAX_FEE_PRV,
   payload,
 });
 
-export const actionFetchedMaxFeePToken = payload => ({
+export const actionFetchedMaxFeePToken = (payload) => ({
   type: ACTION_FETCHED_MAX_FEE_PTOKEN,
   payload,
 });
@@ -94,7 +99,7 @@ export const actionInit = () => ({
   type: ACTION_INIT,
 });
 
-export const actionInitFetched = payload => ({
+export const actionInitFetched = (payload) => ({
   type: ACTION_INIT_FETCHED,
   payload,
 });
@@ -103,7 +108,7 @@ export const actionFetchingFee = () => ({
   type: ACTION_FETCHING_FEE,
 });
 
-export const actionFetchedFee = payload => ({
+export const actionFetchedFee = (payload) => ({
   type: ACTION_FETCHED_FEE,
   payload,
 });
@@ -189,82 +194,181 @@ export const actionFetchFee = ({ amount, address }) => async (
     throw error;
   } finally {
     if (feeEst) {
-      const feePrv = floor(feeEst * rate);
-      const feePrvText = format.toFixed(
-        convert.toHumanAmount(feePrv, CONSTANT_COMMONS.PRV.pDecimals),
-        CONSTANT_COMMONS.PRV.pDecimals
-      );
-      await new Promise.all([
-        await dispatch(
-          actionFetchedFee({
-            feePrv,
-            feePrvText,
-            minFeePrv: feePrv,
-            minFeePrvText: feePrvText,
-          }),
-        ),
-        await dispatch(change(formName, 'fee', feePrvText)),
-        await dispatch(focus(formName, 'fee')),
-      ]);
-    }
-    if (feePTokenEst) {
-      const feePToken = floor(feePTokenEst * rate);
-      const feePTokenText = format.toFixed(
-        convert.toHumanAmount(feePToken, selectedPrivacy?.pDecimals),
-        selectedPrivacy?.pDecimals
-      );
       await dispatch(
-        actionFetchedPTokenFee({
-          feePToken,
-          feePTokenText,
+        actionHandleFeeEst({
+          feeEst,
         }),
       );
     }
+    if (feePTokenEst) {
+      await dispatch(actionHandleFeePTokenEst({ feePTokenEst }));
+    }
     if (minFeePTokenEst) {
-      const minFeePToken = floor(minFeePTokenEst * rate);
-      const minFeePTokenText = format.toFixed(
-        convert.toHumanAmount(minFeePToken, selectedPrivacy?.pDecimals),
-        selectedPrivacy?.pDecimals
-      );
-      await new Promise.all([
-        await dispatch(
-          actionAddFeeType({
-            tokenId: selectedPrivacy?.tokenId,
-            symbol: selectedPrivacy?.externalSymbol || selectedPrivacy?.symbol,
-          }),
-        ),
-        await dispatch(
-          actionFetchedMinPTokenFee({
-            minFeePToken,
-            minFeePTokenText,
-          }),
-        ),
-      ]);
+      await dispatch(actionHandleMinFeeEst({ minFeePTokenEst }));
     }
   }
 };
 
-export const actionAddFeeType = payload => ({
+export const actionHandleMinFeeEst = ({ minFeePTokenEst }) => async (
+  dispatch,
+  getState,
+) => {
+  const state = getState();
+  const selectedPrivacy = selectedPrivacySeleclor.selectedPrivacy(state);
+  const estimateFee = estimateFeeSelector(state);
+  const { rate } = estimateFee;
+  const minFeePToken = floor(minFeePTokenEst * rate);
+  const minFeePTokenText = format.toFixed(
+    convert.toHumanAmount(minFeePToken, selectedPrivacy?.pDecimals),
+    selectedPrivacy?.pDecimals,
+  );
+  await new Promise.all([
+    await dispatch(
+      actionAddFeeType({
+        tokenId: selectedPrivacy?.tokenId,
+        symbol: selectedPrivacy?.externalSymbol || selectedPrivacy?.symbol,
+      }),
+    ),
+    await dispatch(
+      actionFetchedMinPTokenFee({
+        minFeePToken,
+        minFeePTokenText,
+      }),
+    ),
+  ]);
+};
+
+export const actionHandleFeeEst = ({ feeEst }) => async (
+  dispatch,
+  getState,
+) => {
+  const state = getState();
+  const estimateFee = estimateFeeSelector(state);
+  const { rate } = estimateFee;
+  const feePrv = floor(feeEst * rate);
+  const feePrvText = format.toFixed(
+    convert.toHumanAmount(feePrv, CONSTANT_COMMONS.PRV.pDecimals),
+    CONSTANT_COMMONS.PRV.pDecimals,
+  );
+  await new Promise.all([
+    await dispatch(
+      actionFetchedFee({
+        feePrv,
+        feePrvText,
+        minFeePrv: feePrv,
+        minFeePrvText: feePrvText,
+      }),
+    ),
+    await dispatch(change(formName, 'fee', feePrvText)),
+    await dispatch(focus(formName, 'fee')),
+  ]);
+};
+
+export const actionHandleFeePTokenEst = ({ feePTokenEst }) => async (
+  dispatch,
+  getState,
+) => {
+  const state = getState();
+  const selectedPrivacy = selectedPrivacySeleclor.selectedPrivacy(state);
+  const estimateFee = estimateFeeSelector(state);
+  const { rate } = estimateFee;
+  const feePToken = floor(feePTokenEst * rate);
+  const feePTokenText = format.toFixed(
+    convert.toHumanAmount(feePToken, selectedPrivacy?.pDecimals),
+    selectedPrivacy?.pDecimals,
+  );
+  await dispatch(
+    actionFetchedPTokenFee({
+      feePToken,
+      feePTokenText,
+    }),
+  );
+};
+
+export const actionAddFeeType = (payload) => ({
   type: ACTION_ADD_FEE_TYPE,
   payload,
 });
 
-export const actionChangeFeeType = payload => ({
+export const actionChangeFeeType = (payload) => ({
   type: ACTION_CHANGE_FEE_TYPE,
   payload,
 });
 
-export const actionFetchedPTokenFee = payload => ({
+export const actionFetchedPTokenFee = (payload) => ({
   type: ACTION_FETCHED_PTOKEN_FEE,
   payload,
 });
 
-export const actionFetchedMinPTokenFee = payload => ({
+export const actionFetchedMinPTokenFee = (payload) => ({
   type: ACTION_FETCHED_MIN_PTOKEN_FEE,
   payload,
 });
 
-export const actionChangeFee = payload => ({
+export const actionChangeFee = (payload) => ({
   type: ACTION_CHANGE_FEE,
   payload,
 });
+
+export const actionUseFeeMax = () => ({
+  type: ACTION_USE_FEE_MAX,
+});
+
+export const actionFetchFeeByMax = () => async (dispatch, getState) => {
+  const state = getState();
+  const selectedPrivacy = selectedPrivacySeleclor.selectedPrivacy(state);
+  const estimateFee = estimateFeeSelector(state);
+  const { isUseTokenFee } = feeDataSelector(state);
+  const { amount, isMainCrypto, pDecimals, tokenId, isToken } = selectedPrivacy;
+  const { rate, isFetched, feePToken, feePrv, isFetching } = estimateFee;
+  const feeEst = MAX_FEE_PER_TX * rate;
+  let _amount = Math.max(isMainCrypto ? amount - feeEst : amount, 0);
+  let maxAmount = floor(_amount, pDecimals);
+  let maxAmountText = format.toFixed(
+    convert.toHumanAmount(maxAmount, pDecimals),
+    pDecimals,
+  );
+  if (isFetching) {
+    return;
+  }
+  try {
+    if (isFetched) {
+      const { maxAmountText: _maxAmountText } = getMaxAmount({
+        selectedPrivacy,
+        isUseTokenFee,
+        feePToken,
+        feePrv,
+      });
+      maxAmountText = _maxAmountText;
+    } else {
+      await dispatch(actionFetchingFee());
+      await dispatch(actionUseFeeMax());
+      if (isToken) {
+        const feePTokenEstData = await apiGetEstimateFeeFromChain({
+          Prv: feeEst,
+          TokenID: tokenId,
+        });
+        if (feePTokenEstData) {
+          const feePTokenEst = floor(
+            convert.toOriginalAmount(feePTokenEstData, pDecimals),
+            pDecimals,
+          );
+          await new Promise.all([
+            dispatch(actionHandleFeePTokenEst({ feePTokenEst })),
+            dispatch(actionHandleMinFeeEst({ minFeePTokenEst: feePTokenEst })),
+          ]);
+        }
+      }
+      await dispatch(
+        actionHandleFeeEst({
+          feeEst,
+        }),
+      );
+    }
+  } catch (error) {
+    console.log(error);
+  } finally {
+    // eslint-disable-next-line no-unsafe-finally
+    return maxAmountText;
+  }
+};

--- a/src/components/EstimateFee/EstimateFee.constant.js
+++ b/src/components/EstimateFee/EstimateFee.constant.js
@@ -12,3 +12,4 @@ export const ACTION_CHANGE_FEE = '[estimateFee] Change fee';
 export const ACTION_FETCHED_MAX_FEE_PRV = '[estimateFee] Fetched max fee prv';
 export const ACTION_FETCHED_MAX_FEE_PTOKEN =
   '[estimateFee] Fetched max fee pToken';
+export const ACTION_USE_FEE_MAX = '[estimateFee] Use fee max';

--- a/src/components/EstimateFee/EstimateFee.input.js
+++ b/src/components/EstimateFee/EstimateFee.input.js
@@ -30,7 +30,7 @@ const Form = createForm(formName, {
   },
 });
 
-const EstimateFeeInput = props => {
+const EstimateFeeInput = (props) => {
   const { types, isFetching, isFetched } = useSelector(estimateFeeSelector);
   const {
     fee,
@@ -40,6 +40,7 @@ const EstimateFeeInput = props => {
     isUseTokenFee,
     feePrvText,
     feePTokenText,
+    pDecimals,
   } = useSelector(feeDataSelector);
   const [state, setState] = React.useState({
     minFeeValidator: null,
@@ -47,13 +48,14 @@ const EstimateFeeInput = props => {
   });
   const dispatch = useDispatch();
   const { minFeeValidator, maxFeeValidator } = state;
-  const onChangeFee = async value => {
+  const onChangeFee = async (value) => {
     try {
       dispatch(change(formName, 'fee', value));
       dispatch(
         actionChangeFee({
-          field: isUseTokenFee ? 'feePTokenText' : 'feePrvText',
           value,
+          isUseTokenFee,
+          pDecimals,
         }),
       );
     } catch (error) {
@@ -112,7 +114,7 @@ const EstimateFeeInput = props => {
 
 EstimateFeeInput.propTypes = {};
 
-const SupportFeeItem = props => {
+const SupportFeeItem = (props) => {
   const {
     tokenId = null,
     symbol = null,
@@ -147,7 +149,7 @@ const SupportFees = () => {
   if (types.length === 0) {
     return;
   }
-  const onChangeTypeFee = async type => {
+  const onChangeTypeFee = async (type) => {
     await dispatch(actionChangeFeeType(type?.tokenId));
     if (typeof type?.onChangeFee === 'function') {
       type?.onChangeFee(type);

--- a/src/components/EstimateFee/EstimateFee.selector.js
+++ b/src/components/EstimateFee/EstimateFee.selector.js
@@ -1,70 +1,15 @@
 import { createSelector } from 'reselect';
 import { selectedPrivacySeleclor } from '@src/redux/selectors';
-import convert from '@src/utils/convert';
-import { CONSTANT_COMMONS } from '@src/constants';
-import format from '@src/utils/format';
-import floor from 'lodash/floor';
+import { getFeeData } from './EstimateFee.utils';
 
 export const estimateFeeSelector = createSelector(
-  state => state.estimateFee,
-  estimateFee => estimateFee,
+  (state) => state.estimateFee,
+  (estimateFee) => estimateFee,
 );
 
 export const feeDataSelector = createSelector(
   estimateFeeSelector,
   selectedPrivacySeleclor.selectedPrivacy,
   selectedPrivacySeleclor.getPrivacyDataByTokenID,
-  (estimateFee, selectedPrivacy) => {
-    const {
-      actived,
-      minFeePTokenText,
-      minFeePrvText,
-      feePTokenText,
-      feePrvText,
-      maxFeePTokenText,
-      maxFeePrvText,
-      amount,
-      amountText,
-      screen,
-      rate,
-      minAmount,
-      minAmountText,
-    } = estimateFee;
-    const isUseTokenFee = actived !== CONSTANT_COMMONS.PRV.id;
-    const feeUnit = isUseTokenFee
-      ? selectedPrivacy?.externalSymbol || selectedPrivacy.symbol
-      : CONSTANT_COMMONS.PRV.symbol;
-    const feePDecimals = isUseTokenFee
-      ? selectedPrivacy?.pDecimals
-      : CONSTANT_COMMONS.PRV.pDecimals;
-    const fee = isUseTokenFee ? feePTokenText : feePrvText;
-    let amountNumber = convert.toNumber(amountText, true);
-    if (isUseTokenFee || selectedPrivacy?.isMainCrypto) {
-      const newAmount = amountNumber - convert.toNumber(fee);
-      amountNumber = newAmount > 0 ? newAmount : 0;
-    }
-    const maxAmount = Math.max(
-      floor(amountNumber, selectedPrivacy?.pDecimals),
-      0,
-    );
-    const maxAmountText = format.toFixed(maxAmount, selectedPrivacy?.pDecimals);
-    return {
-      isUseTokenFee,
-      fee,
-      feeUnit,
-      feeUnitByTokenId: actived,
-      feePDecimals,
-      minFee: isUseTokenFee ? minFeePTokenText : minFeePrvText,
-      maxFee: isUseTokenFee ? maxFeePTokenText : maxFeePrvText,
-      amount,
-      amountText,
-      screen,
-      rate,
-      minAmount,
-      minAmountText,
-      maxAmount,
-      maxAmountText,
-      isUsedPRVFee: !isUseTokenFee,
-    };
-  },
+  (estimateFee, selectedPrivacy) => getFeeData(estimateFee, selectedPrivacy),
 );

--- a/src/components/EstimateFee/EstimateFee.utils.js
+++ b/src/components/EstimateFee/EstimateFee.utils.js
@@ -1,4 +1,8 @@
 import { MAX_PDEX_TRADE_STEPS } from '@screens/DexV2/constants';
+import convert from '@src/utils/convert';
+import { CONSTANT_COMMONS } from '@src/constants';
+import format from '@src/utils/format';
+import floor from 'lodash/floor';
 
 export const DEFAULT_FEE_PER_KB_HUMAN_AMOUNT = 0.00000001; // in nano
 export const DEFAULT_FEE_PER_KB = DEFAULT_FEE_PER_KB_HUMAN_AMOUNT * 1e9; // in nano
@@ -6,3 +10,78 @@ export const MAX_TX_SIZE = 100;
 export const MAX_FEE_PER_TX = DEFAULT_FEE_PER_KB * MAX_TX_SIZE;
 export const MAX_DEX_FEE = MAX_FEE_PER_TX * MAX_PDEX_TRADE_STEPS;
 export const DEFI_TRADING_FEE = 1000000;
+
+export const getMaxAmount = ({
+  selectedPrivacy,
+  isUseTokenFee,
+  feePToken,
+  feePrv,
+}) => {
+  const { amount, isMainCrypto, pDecimals } = selectedPrivacy;
+  const fee = isUseTokenFee ? feePToken : feePrv;
+  let amountNumber = amount;
+  if (isUseTokenFee || isMainCrypto) {
+    const newAmount = amountNumber - fee;
+    amountNumber = Math.max(newAmount, 0);
+  }
+  const maxAmount = Math.max(floor(amountNumber, pDecimals), 0);
+  const maxAmountText = format.toFixed(
+    convert.toHumanAmount(maxAmount, pDecimals),
+    pDecimals,
+  );
+  return {
+    maxAmount,
+    maxAmountText,
+    fee,
+  };
+};
+
+export const getFeeData = (estimateFee, selectedPrivacy) => {
+  const {
+    actived,
+    minFeePTokenText,
+    minFeePrvText,
+    maxFeePTokenText,
+    maxFeePrvText,
+    amountText,
+    screen,
+    rate,
+    minAmount,
+    minAmountText,
+    feePToken,
+    feePrv,
+  } = estimateFee;
+  const { amount } = selectedPrivacy;
+  const isUseTokenFee = actived !== CONSTANT_COMMONS.PRV.id;
+  const feeUnit = isUseTokenFee
+    ? selectedPrivacy?.externalSymbol || selectedPrivacy.symbol
+    : CONSTANT_COMMONS.PRV.symbol;
+  const feePDecimals = isUseTokenFee
+    ? selectedPrivacy?.pDecimals
+    : CONSTANT_COMMONS.PRV.pDecimals;
+  const { fee, maxAmount, maxAmountText } = getMaxAmount({
+    selectedPrivacy,
+    isUseTokenFee,
+    feePToken,
+    feePrv,
+  });
+  return {
+    isUseTokenFee,
+    fee,
+    feeUnit,
+    feeUnitByTokenId: actived,
+    feePDecimals,
+    minFee: isUseTokenFee ? minFeePTokenText : minFeePrvText,
+    maxFee: isUseTokenFee ? maxFeePTokenText : maxFeePrvText,
+    amount,
+    amountText,
+    screen,
+    rate,
+    minAmount,
+    minAmountText,
+    maxAmount,
+    maxAmountText,
+    isUsedPRVFee: !isUseTokenFee,
+    pDecimals: selectedPrivacy?.pDecimals,
+  };
+};

--- a/src/components/Modal/modal.js
+++ b/src/components/Modal/modal.js
@@ -5,10 +5,10 @@ import {
   TouchableWithoutFeedback,
   SafeAreaView,
 } from 'react-native';
-import {useSelector, useDispatch} from 'react-redux';
-import {COLORS} from '@src/styles';
-import {modalSelector, modalLoadingSelector} from './modal.selector';
-import {actionToggleModal} from './modal.actions';
+import { useSelector, useDispatch } from 'react-redux';
+import { COLORS } from '@src/styles';
+import { modalSelector, modalLoadingSelector } from './modal.selector';
+import { actionToggleModal } from './modal.actions';
 import LoadingModal from './features/LoadingModal';
 
 const styled = StyleSheet.create({
@@ -19,7 +19,7 @@ const styled = StyleSheet.create({
   },
 });
 const ModalComponent = () => {
-  const {visible, data, shouldCloseModalWhenTapOverlay} = useSelector(
+  const { visible, data, shouldCloseModalWhenTapOverlay } = useSelector(
     modalSelector,
   );
   const {
@@ -30,12 +30,14 @@ const ModalComponent = () => {
   const dispatch = useDispatch();
   const handleToggle = async () =>
     shouldCloseModalWhenTapOverlay ? await dispatch(actionToggleModal()) : null;
+  const onRequestClose = async () => await dispatch(actionToggleModal());
   return (
     <Modal
       presentationStyle="overFullScreen"
       animationType="fade"
       visible={visible}
       transparent
+      onRequestClose={onRequestClose}
     >
       <TouchableWithoutFeedback onPress={handleToggle}>
         <SafeAreaView style={styled.container}>

--- a/src/components/UseEffect/index.js
+++ b/src/components/UseEffect/index.js
@@ -1,0 +1,1 @@
+export { default as useBackHandler } from './useBackHandler';

--- a/src/components/UseEffect/useBackHandler.js
+++ b/src/components/UseEffect/useBackHandler.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { BackHandler } from 'react-native';
+import PropTypes from 'prop-types';
+
+const useBackHandler = (props) => {
+  const { onGoBack } = props;
+  const backAction = () =>
+    typeof onGoBack === 'function' ? onGoBack() : null;
+  typeof React.useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      backAction,
+    );
+    return () => backHandler.remove();
+  }, []);
+  return null;
+};
+
+useBackHandler.propTypes = {
+  onGoBack: PropTypes.func.isRequired,
+};
+
+export default useBackHandler;

--- a/src/redux/actions/account.js
+++ b/src/redux/actions/account.js
@@ -283,8 +283,8 @@ export const actionSwitchAccount = (
     const defaultAccount = accountSeleclor.defaultAccount(state);
     if (defaultAccount?.name !== account?.name) {
       await dispatch(setDefaultAccount(account));
-      await dispatch(actionReloadFollowingToken(shouldLoadBalance));
     }
+    await dispatch(actionReloadFollowingToken(shouldLoadBalance));
     return account;
   } catch (error) {
     throw Error(error);

--- a/src/screens/AddManually/AddManually.js
+++ b/src/screens/AddManually/AddManually.js
@@ -36,9 +36,15 @@ const SelectType = () => {
 };
 
 const ModalSelectType = () => {
-  const { isShowChooseType } = React.useContext(AddManuallyContext);
+  const { isShowChooseType, toggleChooseType } = React.useContext(
+    AddManuallyContext,
+  );
   return (
-    <PureModal visible={isShowChooseType} content={<AddManuallyModal />} />
+    <PureModal
+      visible={isShowChooseType}
+      content={<AddManuallyModal />}
+      onRequestClose={toggleChooseType}
+    />
   );
 };
 

--- a/src/screens/Notification/Notification.actions.js
+++ b/src/screens/Notification/Notification.actions.js
@@ -11,6 +11,7 @@ import {
 import { CONSTANT_EVENTS } from '@src/constants';
 import { logEvent } from '@services/firebase';
 import { actionToggleModal } from '@src/components/Modal';
+import { NavigationActions , StackActions } from 'react-navigation';
 import {
   ACTION_FETCHING,
   ACTION_FETCHED,
@@ -36,6 +37,7 @@ import {
   notificationSelector,
 } from './Notification.selector';
 import { mappingData, delay } from './Notification.utils';
+
 
 export const actionHasNoti = (payload) => ({
   type: ACTION_HAS_NOTI,
@@ -221,7 +223,15 @@ export const actionNavigate = (item, navigation) => async (
         return;
       }
       await dispatch(setSelectedPrivacy(tokenId));
-      navigation.navigate(routeNames.WalletDetail);
+      const resetAction = StackActions.reset({
+        index: 2,
+        actions: [
+          NavigationActions.navigate({ routeName: 'Home' }),
+          NavigationActions.navigate({ routeName: 'Wallet' }),
+          NavigationActions.navigate({ routeName: 'WalletDetail' }),
+        ],
+      });
+      navigation.dispatch(resetAction);
       const token = {
         ...getPrivacyDataByTokenID(tokenId),
         id: tokenId,

--- a/src/screens/SendCrypto/SendIn/SendCrypto.js
+++ b/src/screens/SendCrypto/SendIn/SendCrypto.js
@@ -38,11 +38,14 @@ import floor from 'lodash/floor';
 import { actionToggleModal } from '@src/components/Modal';
 import Receipt from '@src/components/Receipt';
 import { CONSTANT_KEYS } from '@src/constants';
+import { actionFetchFeeByMax } from '@src/components/EstimateFee/EstimateFee.actions';
 import { homeStyle } from './style';
 
 export const formName = 'sendCrypto';
 
 const selector = formValueSelector(formName);
+
+const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const initialFormValues = {
   amount: '',
@@ -232,6 +235,13 @@ class SendCrypto extends React.Component {
     rfChange(formName, 'amount', `${amount}`);
   };
 
+  onPressMax = async () => {
+    const { actionFetchFeeByMax, rfChange, rfFocus } = this.props;
+    const maxAmountText = await actionFetchFeeByMax();
+    rfChange(formName, 'amount', maxAmountText);
+    rfFocus(formName, 'amount');
+  };
+
   render() {
     const {
       isSending,
@@ -241,9 +251,7 @@ class SendCrypto extends React.Component {
       onShowFrequentReceivers,
       rfFocus,
       rfChange,
-      feeData,
     } = this.props;
-    const { maxAmountText } = feeData;
     return (
       <View style={homeStyle.container}>
         <Form>
@@ -258,13 +266,9 @@ class SendCrypto extends React.Component {
                 name="amount"
                 placeholder="0.0"
                 label="Amount"
-                maxValue={maxAmountText}
                 componentProps={{
                   keyboardType: 'decimal-pad',
-                  onPressMax: () => {
-                    rfChange(formName, 'amount', maxAmountText);
-                    rfFocus(formName, 'amount');
-                  },
+                  onPressMax: this.onPressMax,
                 }}
                 validate={this.getAmountValidator()}
                 {...generateTestId(SEND.AMtOUNT_INPUT)}
@@ -342,6 +346,7 @@ SendCrypto.propTypes = {
   rfFocus: PropTypes.func.isRequired,
   rfReset: PropTypes.func.isRequired,
   actionToggleModal: PropTypes.func.isRequired,
+  actionFetchFeeByMax: PropTypes.func.isRequired,
 };
 
 const mapState = (state) => ({
@@ -357,8 +362,9 @@ const mapDispatch = {
   setSelectedPrivacy,
   rfChange: change,
   rfFocus: focus,
-  actionToggleModal,
   rfReset: reset,
+  actionToggleModal,
+  actionFetchFeeByMax,
 };
 
 export default connect(

--- a/src/screens/SendCrypto/SendOut/Withdraw.js
+++ b/src/screens/SendCrypto/SendOut/Withdraw.js
@@ -419,26 +419,25 @@ class Withdraw extends React.Component {
                   address.
                 </Text>
               )}
-              {(detectToken.ispBNB(selectedPrivacy?.tokenId) ||
-                selectedPrivacy?.isBep2Token ||
-                selectedPrivacy?.currencyType === 5) && (
-                <View style={style.memoContainer}>
-                  <Field
-                    component={InputQRField}
-                    name="memo"
-                    label="Memo (optional)"
-                    placeholder="Enter a memo"
-                    style={style.input}
-                    validate={memoMaxLength}
-                    maxLength={125}
-                    inputStyle={style.memoInput}
-                  />
-                  <Text style={style.memoText}>
-                    * For withdrawals to wallets on exchanges (e.g. Binance,
-                    etc.), enter your memo to avoid loss of funds.
-                  </Text>
-                </View>
-              )}
+              {selectedPrivacy?.isBep2Token ||
+                (selectedPrivacy?.currencyType === 4 && (
+                  <View style={style.memoContainer}>
+                    <Field
+                      component={InputQRField}
+                      name="memo"
+                      label="Memo (optional)"
+                      placeholder="Enter a memo"
+                      style={style.input}
+                      validate={memoMaxLength}
+                      maxLength={125}
+                      inputStyle={style.memoInput}
+                    />
+                    <Text style={style.memoText}>
+                      * For withdrawals to wallets on exchanges (e.g. Binance,
+                      etc.), enter your memo to avoid loss of funds.
+                    </Text>
+                  </View>
+                ))}
               <EstimateFee
                 amount={
                   isFormValid && !shouldBlockETHWrongAddress ? amount : null

--- a/src/screens/Wallet/features/Detail/Detail.js
+++ b/src/screens/Wallet/features/Detail/Detail.js
@@ -25,6 +25,7 @@ import {
   defaultAccountNameSelector,
 } from '@src/redux/selectors/account';
 import { ScrollView } from '@src/components/core';
+import { useBackHandler } from '@src/components/UseEffect';
 import withDetail from './Detail.enhance';
 import {
   styled,
@@ -152,12 +153,16 @@ const Detail = (props) => {
     !!isFetching || selected?.isMainCrypto
       ? isGettingMainCryptoBalance.length > 0 || !defaultAccountName
       : isGettingTokenBalance.length > 0 || !token;
+  const onGoBack = () => navigation.navigate(routeNames.Wallet);
+
+  useBackHandler({ onGoBack });
+
   return (
     <View style={styled.container}>
       <Header
         title={selected?.name}
         rightHeader={<RightHeader />}
-        onGoBack={() => navigation.navigate(routeNames.Wallet)}
+        onGoBack={onGoBack}
       />
       <ScrollView
         contentContainerStyle={{

--- a/src/screens/Wallet/features/Home/Wallet.enhance.js
+++ b/src/screens/Wallet/features/Home/Wallet.enhance.js
@@ -32,7 +32,7 @@ const enhance = (WrappedComp) => (props) => {
   });
   const { isReloading } = state;
   const navigation = useNavigation();
-  const getFollowingToken = async (shouldLoadBalance) => {
+  const getFollowingToken = async (shouldLoadBalance = true) => {
     try {
       await setState({ isReloading: true });
       await dispatch(actionReloadFollowingToken(shouldLoadBalance));

--- a/src/screens/Wallet/features/Home/Wallet.js
+++ b/src/screens/Wallet/features/Home/Wallet.js
@@ -20,6 +20,7 @@ import Tooltip from '@src/components/Tooltip/Tooltip';
 import { COLORS } from '@src/styles';
 import isNaN from 'lodash/isNaN';
 import { TouchableOpacity } from '@src/components/core';
+import { useBackHandler } from '@src/components/UseEffect';
 import {
   styled,
   styledHook,
@@ -184,12 +185,12 @@ const Extra = () => {
     <View style={extraStyled.container}>
       <ScrollView
         showsVerticalScrollIndicator={false}
-        refreshControl={
+        refreshControl={(
           <RefreshControl
             refreshing={isReloading}
             onRefresh={() => fetchData(true)}
           />
-        }
+        )}
       >
         <Balance />
         <GroupButton />
@@ -216,13 +217,15 @@ const RightHeader = () => {
 
 const Wallet = () => {
   const navigation = useNavigation();
+  const onGoBack = () => navigation.navigate(routeNames.Home);
+  useBackHandler({ onGoBack });
   return (
     <View style={[styled.container]}>
       <Header
         title="Assets"
         rightHeader={<RightHeader />}
         style={styled.hook}
-        onGoBack={() => navigation.navigate(routeNames.Home)}
+        onGoBack={onGoBack}
       />
       <Extra />
     </View>


### PR DESCRIPTION
+ APP-139: Balance is cached when sending/unshield without turn off app or switching account
+ APP-132: [Android] [Testnet] [Select coin type] The device's back button is not working 
+ APP-138: [Mainnet] A account import to 2 accounts show different balance
+ APP-134: Back to Unshield screen from Detail token screen
+ APP-136: [Testnet] [Unshield BNB] Don't show Memo field in the Unshield screen
+ APP-133: Max button should click a time which will work correct when sending/unshielding 

