### PR TITLE
APP-71: [PDex]: Size impact priceUSD is 0 cant devide.

### DIFF
--- a/src/screens/DexV2/components/ExchangeRate/ExchangeRateImpact.js
+++ b/src/screens/DexV2/components/ExchangeRate/ExchangeRateImpact.js
@@ -19,7 +19,7 @@ const convertToUsdNumber = (multiple, multipliedBy, decimal) => {
   return BigNumber(multiple)
     .multipliedBy(BigNumber(multipliedBy))
     .dividedBy(BigNumber(10).pow(decimal))
-    .toNumber();
+    .toNumber() || 0;
 };
 
 const getImpact = (input, output) => {


### PR DESCRIPTION
APP-71: [PDex]: Size impact priceUSD is 0 cant divide, because BigNumber cant devide with top number is 0.