### PR TITLE
[Fix] Resquest send tx view button out of screen on small screen device.

### DIFF
--- a/src/screens/PappView/RequestSendTx.js
+++ b/src/screens/PappView/RequestSendTx.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { View, Text, Button, Container } from '@src/components/core';
+import { View, Text, Button, ScrollView } from '@src/components/core';
 import {
   accountSeleclor,
   tokenSeleclor,
@@ -211,7 +211,7 @@ class RequestSendTx extends Component {
       info,
     } = this.props;
     return (
-      <Container style={requestSendTxStyle.container}>
+      <ScrollView style={requestSendTxStyle.container}>
         <Text style={requestSendTxStyle.title}> REQUEST SEND TX </Text>
         {this.renderData('PAPP URL', url)}
         {this.renderData('To address', toAddress)}
@@ -242,7 +242,7 @@ class RequestSendTx extends Component {
           />
         </View>
         {isSending && <LoadingTx />}
-      </Container>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
Use `ScrollView` in `components/core` instead of `Container`.  
Still need to test on small device simulator to insure this work for different cases.  
(Since I don't have .env config to create dev environment)