### PR TITLE
Inform user of potential deposit maintenance

### DIFF
--- a/src/screens/Shield/features/GenQRCode/GenQRCode.js
+++ b/src/screens/Shield/features/GenQRCode/GenQRCode.js
@@ -44,7 +44,7 @@ const ShieldError = React.memo(({ handleShield }) => {
         title="Try again"
       />
       <Text style={styled.errorText}>
-        {'If that doesn’t work,\n please come back in 60 minutes.'}
+        {'If that doesn’t work,\ncheck the bulletin board for scheduled maintenance.\n\nIf there is none,\nplease come back in an hour.'}
       </Text>
     </View>
   );


### PR DESCRIPTION
I wanted to deposit crypto, but it kept returning a useless message to try again in 60 min.

I'm new to the app and so searched the internet for a possible cause while concerned my funds may be at risk.

Only then have I learned to check the bulletin board which informed me of maintenance.

I think informing a user this way is the easiest, to implement, way to fend off panic.

Long term it would be nice to provide a countdown to how long the maintenance will last instead of generic error messages.

BTW: I don't have an environment configured and so I'm doing line wrapping in my head. Please ensure it looks good before merging.